### PR TITLE
Support to bind internal port to all interfaces

### DIFF
--- a/sia/Dockerfile
+++ b/sia/Dockerfile
@@ -3,7 +3,7 @@ FROM debian
 ARG SIA_VERSION=1.3.1
 
 RUN apt-get update && \
-    apt-get install -y wget unzip && \
+    apt-get install -y wget unzip socat && \
     mkdir -p /sia && \
     wget -O /tmp/sia.zip https://github.com/NebulousLabs/Sia/releases/download/v$SIA_VERSION/Sia-v$SIA_VERSION-linux-amd64.zip && \
     unzip -d /tmp/sia/ /tmp/sia.zip && \
@@ -14,4 +14,6 @@ RUN apt-get update && \
 WORKDIR /sia
 EXPOSE 9981 9982
 
-CMD ["/usr/local/bin/siad"]
+# set "-e EXPOSE_INTERNAL" when calling "docker run" to bind the internal port to 8000
+# this is for testing only and is considered harmful
+CMD if test "$EXPOSE_INTERNAL"; then socat tcp-listen:8000,reuseaddr,fork tcp:localhost:9980 & fi; /usr/local/bin/siad


### PR DESCRIPTION
I'm not sure if you want to merge that - as it exposes the internal SIA port with a workaround
which can be used for testing but should be used with care...